### PR TITLE
Refactor server.py for Python 3 and endpoint handling

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import asyncio
 import websockets
@@ -6,134 +6,129 @@ import socket
 from base64 import b64decode
 import wave
 import json
+from pathlib import Path
+
+PORT = 5000
+DATA_DIR = Path("data")
+DATA_DIR.mkdir(exist_ok=True)
+
+# Map endpoints to output files
+TEXT_ENDPOINTS = {
+    "/accelerometer": "accelerometer.txt",
+    "/gyroscope": "gyroscope.txt",
+    "/magnetometer": "magnetometer.txt",
+    "/orientation": "orientation.txt",
+    "/stepcounter": "stepcounter.txt",
+    "/thermometer": "thermometer.txt",
+    "/lightsensor": "lightsensor.txt",
+    "/proximity": "proximity.txt",
+    "/geolocation": "geolocation.txt",
+}
 
 
 def get_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(('10.255.255.255', 1))
-        IP = s.getsockname()[0]
+        s.connect(("10.255.255.255", 1))
+        return s.getsockname()[0]
     except Exception:
-        IP = '127.0.0.1'
+        return "127.0.0.1"
     finally:
         s.close()
-    return IP
 
 
-hostname = socket.gethostname()
-IPAddr = get_ip()
-# Using 5000 as the default port but you can change based on your requirements
-port = 5000
-print("Your Computer Name is: " + hostname)
-print("Your Computer IP Address is: " + IPAddr)
-print(
-    "* Enter {0}:{1} in the app.\n* Press the 'Set IP Address' button.\n* Select the sensors to stream.\n* Update the 'update interval' by entering a value in ms.".format(IPAddr, port))
+async def handle_text_sensor(path, message):
+    file_path = DATA_DIR / TEXT_ENDPOINTS[path]
+    with open(file_path, "a") as f:
+        f.write(message + "\n")
+    print(f"[{path}] {message}")
 
 
-async def echo(websocket, path):
+async def handle_camera(message):
+    try:
+        payload = json.loads(message)
+        timestamp = payload["Timestamp"]
+        image_data = b64decode(payload["Base64Data"])
+
+        filename = DATA_DIR / f"{timestamp}.png"
+        with open(filename, "wb") as f:
+            f.write(image_data)
+
+        print(f"[camera] Saved image {filename}")
+
+    except Exception as e:
+        print(f"[camera] Error: {e}")
+
+
+async def handle_audio(message):
+    try:
+        pcm_data = b64decode(message)
+
+        pcm_file = DATA_DIR / "temp.pcm"
+        wav_file = DATA_DIR / "audio.wav"
+
+        with open(pcm_file, "ab") as f:
+            f.write(pcm_data)
+
+        with open(pcm_file, "rb") as pcm:
+            pcm_data = pcm.read()
+
+        with wave.open(str(wav_file), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(48000)
+            wav.writeframes(pcm_data)
+
+        print("[audio] Wrote audio.wav")
+
+    except Exception as e:
+        print(f"[audio] Error: {e}")
+
+
+async def handle_pro_audio(message):
+    try:
+        audio_data = b64decode(message)
+        with open(DATA_DIR / "audio.3gp", "ab") as f:
+            f.write(audio_data)
+        print("[pro/audio] Appended audio data")
+
+    except Exception as e:
+        print(f"[pro/audio] Error: {e}")
+
+
+async def websocket_handler(websocket, path):
+    print(f"Client connected to {path}")
+
     async for message in websocket:
-        if path == '/accelerometer':
-            data = await websocket.recv()
-            print(data)
-            f = open("accelerometer.txt", "a")
-            f.write(data+"\n")
 
-        if path == '/gyroscope':
-            data = await websocket.recv()
-            print(data)
-            f = open("gyroscope.txt", "a")
-            f.write(data+"\n")
+        if path in TEXT_ENDPOINTS:
+            await handle_text_sensor(path, message)
 
-        if path == '/magnetometer':
-            data = await websocket.recv()
-            print(data)
-            f = open("magnetometer.txt", "a")
-            f.write(data+"\n")
+        elif path == "/camera":
+            await handle_camera(message)
 
-        if path == '/orientation':
-            data = await websocket.recv()
-            print(data)
-            f = open("orientation.txt", "a")
-            f.write(data+"\n")
+        elif path == "/audio":
+            await handle_audio(message)
 
-        if path == '/stepcounter':
-            data = await websocket.recv()
-            print(data)
-            f = open("stepcounter.txt", "a")
-            f.write(data+"\n")
+        elif path == "/pro/audio":
+            await handle_pro_audio(message)
 
-        if path == '/thermometer':
-            data = await websocket.recv()
-            print(data)
-            f = open("thermometer.txt", "a")
-            f.write(data+"\n")
+        else:
+            print(f"Unknown endpoint: {path}")
 
-        if path == '/lightsensor':
-            data = await websocket.recv()
-            print(data)
-            f = open("lightsensor.txt", "a")
-            f.write(data+"\n")
 
-        if path == '/proximity':
-            data = await websocket.recv()
-            print(data)
-            f = open("proximity.txt", "a")
-            f.write(data+"\n")
-
-        if path == '/geolocation':
-            data = await websocket.recv()
-            print(data)
-            f = open("geolocation.txt", "a")
-            f.write(data+"\n")
-
-        if path == '/camera':
-            try:
-                print("Device connected to camera endpoint")
-                data = await websocket.recv()
-                print("Image received for parsing")
-                parsed_response = json.loads(data)
-                fh = open(str(parsed_response['Timestamp']) + ".png", "wb")
-                fh.write(b64decode(parsed_response['Base64Data']))
-                print("Wrote image with timestamp " +str(parsed_response['Timestamp']))
-            except Exception:
-                print('Connection closed due to error')
-                await websocket.close()
-
-        if path == '/audio':
-            print("Device connected to audio endpoint")
-            data = await websocket.recv()
-            print(data)
-            decoded_data = b64decode(data, ' /')
-            with open('temp.pcm', 'ab') as pcm:
-                pcm.write(decoded_data)
-            with open('temp.pcm', 'rb') as pcm:
-                pcmdata = pcm.read()
-            with wave.open('audio.wav', 'wb') as wav:
-                wav.setnchannels(1)
-                wav.setsampwidth(2)
-                wav.setframerate(48000)
-                wav.setcomptype('NONE', 'NONE')
-                wav.writeframesraw(pcmdata)
-            print("Wrote to audio.wav")
-        
-        if path == '/pro/audio':
-            print("Device connected to unchunked audio endpoint")
-            try:
-                print("Audio Received")
-                print(websocket)
-                print(message)
-                print(len(message))
-                decoded_data = b64decode(message)
-                with open('temp.3gp', 'ab') as gp3:
-                    gp3.write(decoded_data)
-            except e:
-                print(f"Error processing audio: {e}")
-        
-
-# Contribution by Evan Johnston
 async def main():
-    async with websockets.serve(echo, '0.0.0.0', port, max_size=1_000_000_000):
-        await asyncio.Future()
-    
+    ip = get_ip()
+    print(f"Server running at ws://{ip}:{PORT}")
 
-asyncio.run(main())
+    async with websockets.serve(
+        websocket_handler,
+        "0.0.0.0",
+        PORT,
+        max_size=1_000_000_000
+    ):
+        await asyncio.Future()  # run forever
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Hi, I would like the suggest a new server.py

The main problem with the original code is:
1) **Double recv() bug**
You already receive the message here:     ```async for message in websocket:```
But then you do:  ```data = await websocket.recv()``` and read the next message
This causes messages being skipped. The ```data...``` line should be dropped

2) **Fixed invalid exception syntax**
       ```except e: → except Exception as e```

3) **close explicitly the files**
```
f = open("accelerometer.txt", "a")
f.write(data + "\n")
```
these files are never closed. Python closes them when the program exits but this is not a good practice

4)**"Handled binary vs text messages correctly"**
print binary (i.e. audio) data may be risky so I first convert in to ASCII characters
```
image_data = b64decode(payload["Base64Data"])
with open(filename, "wb") as f:
    f.write(image_data)
``